### PR TITLE
Allow `purpose` member on `icons`

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ function validateImages(manifest, memberName, itemName, errors) {
 
         newErrors = validateString(item, 'type', newErrors, { memberPrefix: itemName });
 
-        errors = validateKnownProperties(itemName, item, ['src', 'sizes', 'type'], errors);
+        errors = validateKnownProperties(itemName, item, ['src', 'sizes', 'type', 'purpose'], errors);
       });
     }
   }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -276,6 +276,21 @@ describe('validate', function() {
       assert.deepEqual(validate(manifest), EMPTY);
     });
 
+    it('is valid when element has purpose' , function() {
+      var manifest = {
+        icons: [
+          {
+            src: "icon/lowres.webp",
+            sizes: "16x16 32x32 48x48",
+            type: "image/webp",
+            purpose: "any"
+          }
+        ]
+      };
+
+      assert.deepEqual(validate(manifest), EMPTY);
+    });
+
     it('validates src exists for every icon', function() {
       var manifest = {
         icons: [


### PR DESCRIPTION
This can be found in the spec here: https://w3c.github.io/manifest/#purpose-member
And it is actively being proposed by Lighthouse (to provide masked icons).